### PR TITLE
Add mobile filter bottom drawer to ProductListPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ Do not omit the heading, rename it, or fold it into `### Notes`. This is how
 customers tell at a glance whether an upgrade needs attention.
 -->
 
+## v8.21.0 — Mobile-friendly filter bottom drawer on the product listing page
+
+On screens ≤720px wide, the left filter sidebar on `<ProductListPage>` (and any page mounted under `/shop/[category]`) previously stacked above the product grid and pushed the grid down by ~400–600px of filter chrome before the first product was reachable. This release replaces the stacked sidebar on mobile with a compact toolbar — a "Filters (N)" button showing the count of active filter dimensions, plus the live result count — that opens a bottom drawer containing the same filter form. The drawer slides up from the bottom (220ms, respects `prefers-reduced-motion`), takes `max-height: 85vh`, has a grab-handle, and ends in a sticky footer with **Reset** + **Show {n} results** so picking filters then dismissing the drawer is one tap. Desktop layout is unchanged — sticky 240px sidebar exactly as before.
+
+### No consumer action required
+
+Pin the new tag and reinstall — the mobile behaviour activates from the existing CSS in `@caspian-explorer/script-caspian-store/styles.css` (already imported once at the app root), and `<ProductListPage>` automatically mounts the new drawer. No props changed; `hideFilters` still hides both surfaces.
+
+```bash
+npm install github:CaspianTools/script-caspian-store#v8.21.0
+```
+
+### Added
+
+- [src/components/shop-filter-drawer.tsx](src/components/shop-filter-drawer.tsx): new public `<ShopFilterDrawer>` — bottom-anchored modal that wraps the shared filter form, with overlay-click + Escape + sticky footer (Reset / Show results). Reuses the same body-overflow + Escape conventions as `<CartSheet>`.
+- [src/components/shop-filter-sidebar.tsx](src/components/shop-filter-sidebar.tsx): new public `<ShopFilterFields>` (the body-only filter form, no outer container — drop into a sidebar, dialog, or drawer) and `countActiveShopFilters(state)` helper for badge UIs.
+- [src/components/product-list-page.tsx](src/components/product-list-page.tsx): inline mobile toolbar (filter button with active-count badge + result count) rendered above the grid, hidden on desktop via CSS.
+- [src/i18n/messages.ts](src/i18n/messages.ts): `shop.filters.openMobile`, `shop.filters.openMobileWithCount`, `shop.filters.apply`, `shop.filters.applyWithCount`, `shop.filters.close`.
+
+### Changed
+
+- [src/components/shop-filter-sidebar.tsx](src/components/shop-filter-sidebar.tsx): refactored `<ShopFilterSidebar>` to delegate its body to the new `<ShopFilterFields>`. Public props are unchanged — existing consumers calling `<ShopFilterSidebar state={…} onChange={…} … />` get identical output.
+- [src/styles/globals.css](src/styles/globals.css): at `≤720px`, `.caspian-shop-filter-sidebar` is hidden and `.caspian-shop-mobile-toolbar` is revealed. Added `caspian-drawer-slide-up` keyframes and a `prefers-reduced-motion` opt-out.
+
 ## v8.20.1 — Firestore composite indexes for the three plugin install collections
 
 Storefront checkout was throwing `FirebaseError: The query requires an index` on freshly-deployed projects, because `listPaymentPluginInstalls(db, { onlyEnabled: true })` (and the parallel shipping / email helpers) issues a `where('enabled', '==', true) + orderBy('order', 'asc')` query that requires a composite index Firestore does not autocreate. Existing projects worked because the index had been created out-of-band via the "create here" link in the console error, but a fresh `firebase deploy --only firestore:indexes` would still leave the project broken until that one-off click. This release ships the index definitions in the package so the consumer's `npm run firebase:sync && firebase deploy --only firestore:indexes` flow produces working installs out of the box.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caspian-explorer/script-caspian-store",
-  "version": "8.20.2",
+  "version": "8.21.0",
   "description": "Framework-agnostic React e-commerce store. Bring your own Firebase. Install into any React app (Next.js, Vite, CRA).",
   "license": "MIT",
   "author": "Caspian-Explorer",

--- a/src/components/product-list-page.tsx
+++ b/src/components/product-list-page.tsx
@@ -10,8 +10,12 @@ import { ProductGrid } from './product-grid';
 import {
   ShopFilterSidebar,
   EMPTY_SHOP_FILTERS,
+  countActiveShopFilters,
   type ShopFilterState,
 } from './shop-filter-sidebar';
+import { ShopFilterDrawer } from './shop-filter-drawer';
+import { useT } from '../i18n/locale-context';
+import { Button } from '../ui/button';
 import { cn } from '../utils/cn';
 
 export interface ProductListPageProps {
@@ -72,6 +76,7 @@ export function ProductListPage({
   const [taxConfig, setTaxConfig] = useState<TaxConfig | undefined>(taxConfigOverride);
   const [categories, setCategories] = useState<ProductCategoryDoc[]>([]);
   const [filterState, setFilterState] = useState<ShopFilterState>(EMPTY_SHOP_FILTERS);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
   useEffect(() => {
     let alive = true;
@@ -194,8 +199,26 @@ export function ProductListPage({
       {hideFilters ? (
         grid
       ) : (
-        <div className={cn('caspian-shop-grid')}>
-          <ShopFilterSidebar
+        <>
+          <MobileFilterToolbar
+            activeCount={countActiveShopFilters(filterState)}
+            resultCount={loading ? undefined : visibleProducts.length}
+            onOpen={() => setMobileFiltersOpen(true)}
+          />
+          <div className={cn('caspian-shop-grid')}>
+            <ShopFilterSidebar
+              state={filterState}
+              onChange={setFilterState}
+              availableCategories={availableCategories}
+              categoryLabels={categoryLabels}
+              availableSizes={availableSizes}
+              resultCount={loading ? undefined : visibleProducts.length}
+            />
+            <div style={{ minWidth: 0 }}>{grid}</div>
+          </div>
+          <ShopFilterDrawer
+            open={mobileFiltersOpen}
+            onOpenChange={setMobileFiltersOpen}
             state={filterState}
             onChange={setFilterState}
             availableCategories={availableCategories}
@@ -203,8 +226,43 @@ export function ProductListPage({
             availableSizes={availableSizes}
             resultCount={loading ? undefined : visibleProducts.length}
           />
-          <div style={{ minWidth: 0 }}>{grid}</div>
-        </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function MobileFilterToolbar({
+  activeCount,
+  resultCount,
+  onOpen,
+}: {
+  activeCount: number;
+  resultCount: number | undefined;
+  onOpen: () => void;
+}) {
+  const t = useT();
+  return (
+    <div
+      className="caspian-shop-mobile-toolbar"
+      style={{
+        display: 'none',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        marginBottom: 16,
+      }}
+    >
+      <Button type="button" variant="outline" size="sm" onClick={onOpen}>
+        <span aria-hidden="true" style={{ marginRight: 6 }}>☰</span>
+        {activeCount > 0
+          ? t('shop.filters.openMobileWithCount', { count: activeCount })
+          : t('shop.filters.openMobile')}
+      </Button>
+      {typeof resultCount === 'number' && (
+        <span style={{ fontSize: 13, color: '#666' }}>
+          {t('shop.filters.resultCount', { count: resultCount })}
+        </span>
       )}
     </div>
   );

--- a/src/components/shop-filter-drawer.tsx
+++ b/src/components/shop-filter-drawer.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useT } from '../i18n/locale-context';
+import { Button } from '../ui/button';
+import { cn } from '../utils/cn';
+import {
+  EMPTY_SHOP_FILTERS,
+  ShopFilterFields,
+  countActiveShopFilters,
+  type ShopFilterFieldsProps,
+  type ShopFilterState,
+} from './shop-filter-sidebar';
+
+export interface ShopFilterDrawerProps
+  extends Omit<ShopFilterFieldsProps, 'hideHeader' | 'hideReset'> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  className?: string;
+}
+
+/**
+ * Mobile-first bottom drawer wrapping the shared filter fields. Reuses the
+ * same overlay + Escape + body-overflow conventions as `<CartSheet>`, but
+ * anchors to the bottom edge and shows a sticky footer with Reset + Apply.
+ */
+export function ShopFilterDrawer({
+  open,
+  onOpenChange,
+  state,
+  onChange,
+  availableCategories,
+  categoryLabels,
+  availableSizes,
+  resultCount,
+  className,
+}: ShopFilterDrawerProps) {
+  const t = useT();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false);
+    };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  const hasActive = countActiveShopFilters(state) > 0;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        zIndex: 900,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-end',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onOpenChange(false);
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('shop.filters.title')}
+    >
+      <aside
+        className={cn('caspian-shop-filter-drawer', className)}
+        style={{
+          width: '100%',
+          maxHeight: '85vh',
+          background: '#fff',
+          color: '#111',
+          borderTopLeftRadius: 'var(--caspian-radius, 12px)',
+          borderTopRightRadius: 'var(--caspian-radius, 12px)',
+          boxShadow: '0 -8px 32px rgba(0,0,0,0.18)',
+          display: 'flex',
+          flexDirection: 'column',
+          animation: 'caspian-drawer-slide-up 220ms ease-out',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            padding: '8px 0 4px',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 36,
+              height: 4,
+              borderRadius: 999,
+              background: 'rgba(0,0,0,0.18)',
+            }}
+          />
+        </div>
+
+        <header
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '8px 20px 12px',
+            borderBottom: '1px solid rgba(0,0,0,0.08)',
+          }}
+        >
+          <h2 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>
+            {t('shop.filters.title')}
+          </h2>
+          <button
+            type="button"
+            aria-label={t('shop.filters.close')}
+            onClick={() => onOpenChange(false)}
+            style={{
+              background: 'transparent',
+              border: 0,
+              fontSize: 22,
+              cursor: 'pointer',
+              lineHeight: 1,
+              padding: 4,
+              color: '#444',
+            }}
+          >
+            ×
+          </button>
+        </header>
+
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            padding: '16px 20px 20px',
+          }}
+        >
+          <ShopFilterFields
+            state={state}
+            onChange={onChange}
+            availableCategories={availableCategories}
+            categoryLabels={categoryLabels}
+            availableSizes={availableSizes}
+            resultCount={resultCount}
+            hideHeader
+            hideReset
+          />
+        </div>
+
+        <footer
+          style={{
+            display: 'flex',
+            gap: 12,
+            padding: '12px 20px max(12px, env(safe-area-inset-bottom))',
+            borderTop: '1px solid rgba(0,0,0,0.08)',
+            background: '#fff',
+          }}
+        >
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onChange(EMPTY_SHOP_FILTERS)}
+            disabled={!hasActive}
+            style={{ flex: '0 0 auto' }}
+          >
+            {t('shop.filters.reset')}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            style={{ flex: 1 }}
+          >
+            {typeof resultCount === 'number'
+              ? t('shop.filters.applyWithCount', { count: resultCount })
+              : t('shop.filters.apply')}
+          </Button>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+export type { ShopFilterState };

--- a/src/components/shop-filter-sidebar.tsx
+++ b/src/components/shop-filter-sidebar.tsx
@@ -21,20 +21,35 @@ export const EMPTY_SHOP_FILTERS: ShopFilterState = {
   limited: false,
 };
 
-export interface ShopFilterSidebarProps {
+/** Count of distinct filter dimensions currently active. Useful for badge UIs. */
+export function countActiveShopFilters(state: ShopFilterState): number {
+  let n = 0;
+  if (state.category !== null) n += 1;
+  if (state.minPrice !== '' || state.maxPrice !== '') n += 1;
+  if (state.sizes.size > 0) n += 1;
+  if (state.isNew) n += 1;
+  if (state.limited) n += 1;
+  return n;
+}
+
+export interface ShopFilterFieldsProps {
   state: ShopFilterState;
   onChange: (next: ShopFilterState) => void;
-  /** Categories present in the loaded product set; the radio list. */
   availableCategories: readonly string[];
-  /** Map from category value (the string stored on `product.category`, usually
-   *  a Firestore category id) to the human display label. When omitted, or
-   *  when a value isn't in the map, the raw value is shown — matches the
-   *  legacy behaviour for free-text categories. */
   categoryLabels?: ReadonlyMap<string, string>;
-  /** Sizes present in the loaded product set; the chip checkboxes. */
   availableSizes: readonly string[];
   /** Total number of products visible after filters apply. Renders the count line. */
   resultCount?: number;
+  /** When true, the header/title row is omitted — useful when the drawer or
+   *  sidebar already provides its own chrome. */
+  hideHeader?: boolean;
+  /** When true, omit the inline Reset button — drawers typically render it in
+   *  a sticky footer instead. */
+  hideReset?: boolean;
+}
+
+export interface ShopFilterSidebarProps
+  extends Omit<ShopFilterFieldsProps, 'hideHeader' | 'hideReset'> {
   className?: string;
 }
 
@@ -66,15 +81,21 @@ const radioRowStyle: React.CSSProperties = {
   cursor: 'pointer',
 };
 
-export function ShopFilterSidebar({
+/**
+ * Body-only filter form. Renders all sections (category, price, size, quick
+ * filters) without an outer container — drop into a sidebar `<aside>`, a
+ * dialog, or a mobile drawer.
+ */
+export function ShopFilterFields({
   state,
   onChange,
   availableCategories,
   categoryLabels,
   availableSizes,
   resultCount,
-  className,
-}: ShopFilterSidebarProps) {
+  hideHeader,
+  hideReset,
+}: ShopFilterFieldsProps) {
   const t = useT();
 
   const setCategory = (cat: string | null) => onChange({ ...state, category: cat });
@@ -88,42 +109,27 @@ export function ShopFilterSidebar({
   };
   const reset = () => onChange(EMPTY_SHOP_FILTERS);
 
-  const hasActiveFilters =
-    state.category !== null ||
-    state.minPrice !== '' ||
-    state.maxPrice !== '' ||
-    state.sizes.size > 0 ||
-    state.isNew ||
-    state.limited;
+  const hasActiveFilters = countActiveShopFilters(state) > 0;
 
   return (
-    <aside
-      className={cn('caspian-shop-filter-sidebar', className)}
-      style={{
-        padding: 20,
-        border: '1px solid rgba(0,0,0,0.08)',
-        borderRadius: 'var(--caspian-radius, 8px)',
-        background: '#fff',
-        alignSelf: 'start',
-        position: 'sticky',
-        top: 16,
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'baseline',
-          justifyContent: 'space-between',
-          marginBottom: 18,
-        }}
-      >
-        <h2 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>{t('shop.filters.title')}</h2>
-        {typeof resultCount === 'number' && (
-          <span style={{ fontSize: 12, color: '#888' }}>
-            {t('shop.filters.resultCount', { count: resultCount })}
-          </span>
-        )}
-      </div>
+    <>
+      {!hideHeader && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'space-between',
+            marginBottom: 18,
+          }}
+        >
+          <h2 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>{t('shop.filters.title')}</h2>
+          {typeof resultCount === 'number' && (
+            <span style={{ fontSize: 12, color: '#888' }}>
+              {t('shop.filters.resultCount', { count: resultCount })}
+            </span>
+          )}
+        </div>
+      )}
 
       {availableCategories.length > 0 && (
         <div style={sectionStyle}>
@@ -228,7 +234,7 @@ export function ShopFilterSidebar({
         </label>
       </div>
 
-      {hasActiveFilters && (
+      {!hideReset && hasActiveFilters && (
         <button
           type="button"
           onClick={reset}
@@ -245,6 +251,28 @@ export function ShopFilterSidebar({
           {t('shop.filters.reset')}
         </button>
       )}
+    </>
+  );
+}
+
+export function ShopFilterSidebar({
+  className,
+  ...fieldsProps
+}: ShopFilterSidebarProps) {
+  return (
+    <aside
+      className={cn('caspian-shop-filter-sidebar', className)}
+      style={{
+        padding: 20,
+        border: '1px solid rgba(0,0,0,0.08)',
+        borderRadius: 'var(--caspian-radius, 8px)',
+        background: '#fff',
+        alignSelf: 'start',
+        position: 'sticky',
+        top: 16,
+      }}
+    >
+      <ShopFilterFields {...fieldsProps} />
     </aside>
   );
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -204,6 +204,11 @@ export const DEFAULT_MESSAGES: MessageDict = {
   'shop.filters.limited': 'Limited',
   'shop.filters.reset': 'Reset filters',
   'shop.filters.resultCount': '{count} products',
+  'shop.filters.openMobile': 'Filters',
+  'shop.filters.openMobileWithCount': 'Filters ({count})',
+  'shop.filters.apply': 'Show results',
+  'shop.filters.applyWithCount': 'Show {count} results',
+  'shop.filters.close': 'Close filters',
 
   // Product detail page
   'product.size': 'Size',

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,17 @@ export { ProductGrid, type ProductGridProps } from './components/product-grid';
 export { ProductListPage, type ProductListPageProps } from './components/product-list-page';
 export {
   ShopFilterSidebar,
+  ShopFilterFields,
   EMPTY_SHOP_FILTERS,
+  countActiveShopFilters,
   type ShopFilterSidebarProps,
+  type ShopFilterFieldsProps,
   type ShopFilterState,
 } from './components/shop-filter-sidebar';
+export {
+  ShopFilterDrawer,
+  type ShopFilterDrawerProps,
+} from './components/shop-filter-drawer';
 export { CollectionsPage, type CollectionsPageProps } from './components/collections-page';
 export {
   CollectionDetailPage,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -76,4 +76,27 @@ a:focus-visible {
     grid-template-columns: 1fr;
     gap: 16px;
   }
+  /* On mobile the inline filter sidebar is replaced by a button that opens
+     the bottom drawer (see <ShopFilterDrawer>). */
+  .caspian-shop-filter-sidebar {
+    display: none !important;
+  }
+  .caspian-shop-mobile-toolbar {
+    display: flex !important;
+  }
+}
+
+@keyframes caspian-drawer-slide-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caspian-shop-filter-drawer {
+    animation: none !important;
+  }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated from package.json by tsup.config.ts. Do not edit.
-export const CASPIAN_STORE_VERSION = '8.20.2';
+export const CASPIAN_STORE_VERSION = '8.21.0';


### PR DESCRIPTION
On screens ≤720px the inline filter sidebar previously stacked above
the product grid, pushing every product offscreen until the user
scrolled past 400–600px of filter chrome. Replace it on mobile with a
toolbar (filter button with active-count badge + result count) that
opens a bottom drawer; desktop keeps the sticky 240px sidebar.

The drawer reuses the body-overflow + Escape conventions from
CartSheet, slides up 220ms with a prefers-reduced-motion opt-out,
caps at 85vh, and ends in a sticky footer with Reset / Show {n}
results so picking filters and dismissing the drawer is one tap.

Public API is additive — ShopFilterSidebar props are unchanged
(its body is now delegated to the new ShopFilterFields), and three
new exports are added: ShopFilterDrawer, ShopFilterFields,
countActiveShopFilters.